### PR TITLE
salita -u salita

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,22 +19,21 @@
     "Jordan Harband <ljharb@gmail.com> (https://github.com/ljharb/)"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.3.0",
     "cli-table": "^0.3.1",
+    "for-each": "^0.3.2",
     "json-file-plus": "^3.3.0",
-    "npm": "^3.10.8",
-    "yargs": "^5.0.0",
+    "npm": "^5.5.1",
     "object.assign": "^4.0.4",
-    "promise": "^7.1.1",
-    "semver": "^5.3.0",
-    "for-each": "^0.3.2"
+    "promise": "^8.0.1",
+    "semver": "^5.4.1",
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
-    "eslint": "^3.6.1",
-    "@ljharb/eslint-config": "^8.0.0"
+    "eslint": "^4.12.1",
+    "@ljharb/eslint-config": "^12.2.1"
   },
   "author": "Tim Branyen (@tbranyen)",
   "license": "MIT"
 }
-


### PR DESCRIPTION
Upgrading npm addresses the `log.gauge.isEnabled()` error:

$ salita -u
...npmlog/log.js:57
log.progressEnabled = log.gauge.isEnabled()
                                ^

TypeError: log.gauge.isEnabled is not a function
    at Object.<anonymous>