### PR TITLE
Support updating bundled and optional dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,9 @@ var salita = function salita(dir, options, callback) {
     var deps = {
       dependencies: 'Dependencies',
       devDependencies: 'Development Dependencies',
-      peerDependencies: 'Peer Dependencies'
+      peerDependencies: 'Peer Dependencies',
+      bundledDependencies: 'Bundled Dependencies',
+      optionalDependencies: 'Optional Dependencies'
     };
 
     var depLookups = [];


### PR DESCRIPTION
I just noticed salita didn't handle bundled or optional deps, and it seems like it'd be a generally-reasonable thing to add.